### PR TITLE
Add link elements to resume contact info

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2298,6 +2298,10 @@ a:hover, .bauen-prose a:hover {
   text-decoration-line: underline;
 }
 
+.no-underline {
+  text-decoration-line: none;
+}
+
 .shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);

--- a/layouts/_default/resume.html
+++ b/layouts/_default/resume.html
@@ -21,7 +21,11 @@
   </h1>
   <p class="mt-2 pb-2 pl-1 print:pl-0 print:mt-0 text-gray-500 border-b-2 rounded-sm border-green-600">
     <span class="print:hidden">{{ .Description }}</span>
-    <span class="hidden print:block text-gray-700">isaac@braunbauen.com | github.com/isaacbraun | braunbauen.com</span>
+    <span class="hidden print:block text-gray-700">
+      <a class="no-underline" href="mailto:isaac@braunbauen.com" title="Email Isaac">isaac@braunbauen.com</a> | 
+      <a class="no-underline" href="https://github.com/isaacbraun" title="Visit Isaac's GitHub">github.com/isaacbraun</a> | 
+      <a class="no-underline" href="https://braunbauen.com" title="Visit Isaac's Website">braunbauen.com</a>
+    </span>
   </p>
   <section>{{ .Content }}</section>
 </main>


### PR DESCRIPTION
The three links/pieces of contact information in the print version of the resume page were only text.

This change makes them clickable links for easier access.
